### PR TITLE
Use timestamp when saving sessions

### DIFF
--- a/app.py
+++ b/app.py
@@ -160,10 +160,11 @@ def save_current_session():
     try:
         session_data = st.session_state.session.to_dict()
         session_id = st.session_state.session.session_id
-        save_session(session_data, session_id)
-        
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        st.success(f"Session saved (ID: {session_id[:8]}...)")
+        session_data["saved_at"] = timestamp
+        save_session(session_data, session_id)
+
+        st.success(f"Session saved at {timestamp} (ID: {session_id[:8]}...)")
         return session_id
     except Exception as e:
         st.error(f"Failed to save session: {str(e)}")


### PR DESCRIPTION
## Summary
- Capture a timestamp when saving a session and include it in the stored data
- Display the save time in the confirmation message for user context

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b454436be883288a0ce780e51b0488