### PR TITLE
Use Fernet for session encryption

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-dotenv>=1.0.0
 pydantic>=2.0.0
 numpy>=1.24.0
 loguru>=0.7.0
+cryptography>=41.0.0


### PR DESCRIPTION
## Summary
- replace custom XOR cipher with `cryptography.Fernet`
- load encryption key from `MAI_DX_SECRET` environment variable
- add `cryptography` to requirements

## Testing
- `python -m py_compile mai_dx/persistence.py`
- `pip install cryptography` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b4583d42a48328834a400ed1be8a35