### PR TITLE
Improve function call output parsing in MAI-DxO

### DIFF
--- a/tests/test_extract_function_call_output.py
+++ b/tests/test_extract_function_call_output.py
@@ -1,0 +1,61 @@
+import importlib
+import os
+import sys
+import types
+
+
+import pytest
+
+
+@pytest.fixture
+def main_module(monkeypatch):
+    """Import mai_dx.main with stubbed dependencies."""
+
+    swarms_stub = types.ModuleType("swarms")
+
+    class DummyAgent:  # pragma: no cover - minimal stub
+        pass
+
+    swarms_stub.Agent = DummyAgent
+    swarms_stub.Conversation = DummyAgent
+    monkeypatch.setitem(sys.modules, "swarms", swarms_stub)
+
+    dotenv_stub = types.ModuleType("dotenv")
+
+    def fake_load_dotenv(*args, **kwargs):  # pragma: no cover - minimal stub
+        return None
+
+    dotenv_stub.load_dotenv = fake_load_dotenv
+    monkeypatch.setitem(sys.modules, "dotenv", dotenv_stub)
+
+    root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    if root not in sys.path:
+        sys.path.insert(0, root)
+
+    main = importlib.import_module("mai_dx.main")
+    importlib.reload(main)
+    return main
+
+
+def test_list_response_parsed(main_module):
+    orchestrator = main_module.MaiDxOrchestrator.__new__(
+        main_module.MaiDxOrchestrator
+    )
+    response = [
+        {"action_type": "ask", "content": "Age?", "reasoning": "Need age"}
+    ]
+    result = orchestrator._extract_function_call_output(response)
+    assert result == response[0]
+
+
+def test_single_quoted_string_parsed(main_module):
+    orchestrator = main_module.MaiDxOrchestrator.__new__(
+        main_module.MaiDxOrchestrator
+    )
+    response = (
+        "{'action_type': 'ask', 'content': 'Age?', 'reasoning': 'Need age'}"
+    )
+    expected = {"action_type": "ask", "content": "Age?", "reasoning": "Need age"}
+    result = orchestrator._extract_function_call_output(response)
+    assert result == expected
+


### PR DESCRIPTION
## Summary
- Add recursive list handling and fallback parsing via `ast.literal_eval`
- Import `ast` for literal evaluation
- Test list responses and single-quoted strings are parsed to actions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4660a638483288351fa6656b74965