### PR TITLE
Handle function dicts in response extraction

### DIFF
--- a/mai_dx/main.py
+++ b/mai_dx/main.py
@@ -427,8 +427,14 @@ class MaiDxOrchestrator:
                     if "function" in tool_call and "arguments" in tool_call["function"]:
                         args = tool_call["function"]["arguments"]
                         return json.loads(args) if isinstance(args, str) else args
+                if "function" in agent_response and "arguments" in agent_response["function"]:
+                    args = agent_response["function"]["arguments"]
+                    return json.loads(args) if isinstance(args, str) else args
                 # Fallback for simple dicts that might be the arguments themselves
-                if "action_type" in agent_response and "content" in agent_response:
+                if all(
+                    key in agent_response
+                    for key in ("action_type", "content", "reasoning")
+                ):
                     return agent_response
 
             # Handle string response which might contain a JSON object

--- a/tests/test_extract_function_call_output.py
+++ b/tests/test_extract_function_call_output.py
@@ -59,3 +59,28 @@ def test_single_quoted_string_parsed(main_module):
     result = orchestrator._extract_function_call_output(response)
     assert result == expected
 
+
+def test_function_dict_parsed(main_module):
+    orchestrator = main_module.MaiDxOrchestrator.__new__(
+        main_module.MaiDxOrchestrator
+    )
+    response = {
+        "function": {
+            "arguments": (
+                '{"action_type": "ask", "content": "Age?", "reasoning": "Need age"}'
+            )
+        }
+    }
+    expected = {"action_type": "ask", "content": "Age?", "reasoning": "Need age"}
+    result = orchestrator._extract_function_call_output(response)
+    assert result == expected
+
+
+def test_missing_reasoning_returns_none(main_module):
+    orchestrator = main_module.MaiDxOrchestrator.__new__(
+        main_module.MaiDxOrchestrator
+    )
+    response = {"action_type": "ask", "content": "Age?"}
+    result = orchestrator._extract_function_call_output(response)
+    assert result is None
+


### PR DESCRIPTION
## Summary
- extend `_extract_function_call_output` to parse top-level `function` dictionaries
- ensure responses include `action_type`, `content`, and `reasoning`
- add tests for new parsing logic and missing reasoning fallback

## Testing
- `pytest -q`
- `streamlit run app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4691986cc832897a0973f2e109552