### PR TITLE
Check swarms package exports and warn on shadowing

### DIFF
--- a/mai_dx/main.py
+++ b/mai_dx/main.py
@@ -32,7 +32,7 @@ from mai_dx.utils import resilient_parser
 # Dependencies are listed in requirements.txt and can be installed using
 # `pip install -r requirements.txt` or the `scripts/install_dependencies.py` script.
 try:
-    from swarms import Agent, Conversation
+    import swarms
     from dotenv import load_dotenv
 except ImportError as e:
     raise ImportError(
@@ -40,6 +40,18 @@ except ImportError as e:
         " Please install them with 'pip install -r requirements.txt' or run"
         " 'python scripts/install_dependencies.py'."
     ) from e
+
+missing_attrs = [attr for attr in ("Agent", "Conversation") if not hasattr(swarms, attr)]
+if missing_attrs:
+    raise ImportError(
+        "The 'swarms' package is missing required attributes: "
+        f"{', '.join(missing_attrs)}. This may occur if a local package named 'swarms'"
+        " is shadowing the intended external dependency. Please rename or remove any"
+        " local directories named 'swarms'."
+    )
+
+Agent = swarms.Agent
+Conversation = swarms.Conversation
 
 load_dotenv()
 

--- a/tests/test_swarms_shadowing.py
+++ b/tests/test_swarms_shadowing.py
@@ -1,0 +1,20 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+def test_shadowed_swarms_package_warns(monkeypatch):
+    """Importing mai_dx.main with a shadowed swarms module should raise hint."""
+    fake_swarms = types.ModuleType("swarms")
+    monkeypatch.setitem(sys.modules, "swarms", fake_swarms)
+
+    dotenv_stub = types.ModuleType("dotenv")
+    dotenv_stub.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", dotenv_stub)
+
+    sys.modules.pop("mai_dx.main", None)
+    with pytest.raises(ImportError) as exc:
+        importlib.import_module("mai_dx.main")
+    assert "rename or remove any local directories named 'swarms'" in str(exc.value)


### PR DESCRIPTION
## Summary
- Validate that the imported `swarms` module exposes `Agent` and `Conversation`
- Provide clear ImportError hinting at local `swarms` directory shadowing
- Add unit test ensuring shadowed `swarms` triggers helpful message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6f7437bc88328b973dff4287d9e02