### PR TITLE
Perf: optimize estimate_cost lookup quick win

### DIFF
--- a/mai_dx/costing.py
+++ b/mai_dx/costing.py
@@ -1,8 +1,13 @@
-"""
-Manages cost estimation for medical tests in the DxO simulation.
-"""
-from typing import Dict, List, Union
+"""Manages cost estimation for medical tests in the DxO simulation."""
+from functools import lru_cache
+from typing import Dict, List, Union, Tuple, Set
 from config import DEFAULT_TEST_COSTS
+
+
+@lru_cache(maxsize=32)
+def _keyword_sets(keys: Tuple[str, ...]) -> Dict[str, Set[str]]:
+    """Precompute split keyword sets for cost database keys."""
+    return {k: set(k.split()) for k in keys}
 
 def estimate_cost(
     tests: Union[List[str], str], test_cost_db: Dict[str, int]
@@ -21,17 +26,22 @@ def estimate_cost(
     """
     if isinstance(tests, str):
         tests = [tests]
+
     cost = 0
+    # Precompute keyword sets for this database, caching by keys tuple
+    keyword_sets = _keyword_sets(tuple(test_cost_db.keys()))
+
     for test in tests:
         test_lower = test.lower().strip()
         if not test_lower:
             continue
 
+        test_words = set(test_lower.split())
         # Find the best matching key in the cost database
         best_match = max(
-            test_cost_db.keys(),
-            key=lambda k: len(set(k.split()) & set(test_lower.split())),
-            default="default",
-        )
+            keyword_sets.items(),
+            key=lambda item: len(item[1] & test_words),
+            default=("default", set()),
+        )[0]
         cost += test_cost_db.get(best_match, test_cost_db.get("default", 150))
     return cost


### PR DESCRIPTION
## Summary
- cache split keywords for cost database to avoid repeated work in estimate_cost
- use cached keyword sets to reduce cost estimation overhead

## Testing
- `pytest -q`
- `python -m timeit -s "from mai_dx.costing import estimate_cost; from config import DEFAULT_TEST_COSTS; tests=['chest x-ray','cbc','ultrasound','mri','blood glucose']*20" "estimate_cost(tests, DEFAULT_TEST_COSTS)"`


------
https://chatgpt.com/codex/tasks/task_e_68b728cdb6508328a0ffc381a9a7abde